### PR TITLE
Update to debian bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y kannel=1.4.5-9
+RUN apt-get update && apt-get install -y kannel=1.4.5-12
 
 
 COPY kannel.conf /etc/kannel/kannel.conf


### PR DESCRIPTION
Debian bookworm is the latest debian, so it is probably time to update this.

The `-9` patch version is not available on bookworm, so I also updated the requested kannel to `-12` which has some minor changes, but nothing that should impact the running kannel.